### PR TITLE
Adding gradio demo python files for sdxl, controlNet(depth) & Multidiffusion

### DIFF
--- a/demo_stylealigned_controlnet.py
+++ b/demo_stylealigned_controlnet.py
@@ -1,0 +1,126 @@
+import gradio as gr
+from diffusers import ControlNetModel, StableDiffusionXLControlNetPipeline, AutoencoderKL
+from diffusers.utils import load_image
+from transformers import DPTImageProcessor, DPTForDepthEstimation
+import torch
+import sa_handler
+import pipeline_calls
+
+
+
+# Initialize models
+depth_estimator = DPTForDepthEstimation.from_pretrained("Intel/dpt-hybrid-midas").to("cuda")
+feature_processor = DPTImageProcessor.from_pretrained("Intel/dpt-hybrid-midas")
+
+controlnet = ControlNetModel.from_pretrained(
+    "diffusers/controlnet-depth-sdxl-1.0",
+    variant="fp16",
+    use_safetensors=True,
+    torch_dtype=torch.float16,
+).to("cuda")
+vae = AutoencoderKL.from_pretrained("madebyollin/sdxl-vae-fp16-fix", torch_dtype=torch.float16).to("cuda")
+pipeline = StableDiffusionXLControlNetPipeline.from_pretrained(
+    "stabilityai/stable-diffusion-xl-base-1.0",
+    controlnet=controlnet,
+    vae=vae,
+    variant="fp16",
+    use_safetensors=True,
+    torch_dtype=torch.float16,
+).to("cuda")
+# Configure pipeline for CPU offloading and VAE slicing
+pipeline.enable_model_cpu_offload()
+pipeline.enable_vae_slicing()
+
+# Initialize style-aligned handler
+sa_args = sa_handler.StyleAlignedArgs(share_group_norm=False,
+                                      share_layer_norm=False,
+                                      share_attention=True,
+                                      adain_queries=True,
+                                      adain_keys=True,
+                                      adain_values=False,
+                                     )
+handler = sa_handler.Handler(pipeline)
+handler.register(sa_args, )
+
+
+# Function to run ControlNet depth with StyleAligned
+def style_aligned_controlnet(ref_style_prompt, depth_map, ref_image, img_generation_prompt):
+    try:
+        if depth_map == True:
+            image = load_image(ref_image)
+            depth_image = pipeline_calls.get_depth_map(image, feature_processor, depth_estimator)
+        else:
+            depth_image = load_image(ref_image).resize((1024, 1024))
+        controlnet_conditioning_scale = 0.8
+        num_images_per_prompt = 3 # adjust according to VRAM size
+        latents = torch.randn(1 + num_images_per_prompt, 4, 128, 128).to(pipeline.unet.dtype)
+        latents[1:] = torch.randn(num_images_per_prompt, 4, 128, 128).to(pipeline.unet.dtype)
+        images = pipeline_calls.controlnet_call(pipeline, [ref_style_prompt, img_generation_prompt],
+                                                image=depth_image,
+                                                num_inference_steps=50,
+                                                controlnet_conditioning_scale=controlnet_conditioning_scale,
+                                                num_images_per_prompt=num_images_per_prompt,
+                                                latents=latents)
+        return [images[0], depth_image] +  images[1:], gr.Image(value=images[0], visible=True)
+    except Exception as e:
+        raise gr.Error(f"Error in generating images:{e}")
+
+# Create a Gradio UI
+with gr.Blocks() as demo:
+    gr.HTML('<h1 style="text-align: center;">Style-aligned with ControlNet Depth</h1>')
+    with gr.Row():
+      
+      with gr.Column(variant='panel'):
+        # Textbox for reference style prompt
+        ref_style_prompt = gr.Textbox(
+          label='Reference style prompt',
+          info="Enter a Prompt to generate the reference image", placeholder='a poster in <style name> style'
+        )
+        # Checkbox for using controller depth-map
+        depth_map = gr.Checkbox(label='Depth-map',)
+        # Image display for the generated reference style image
+        ref_style_image = gr.Image(visible=False, label='Reference style image')
+      
+      with gr.Column(variant='panel'): 
+        # Image upload option for uploading a reference image for controlnet
+        ref_image = gr.Image(label="Upload the reference image", 
+                             type='filepath' )
+        # Textbox for ControlNet prompt
+        img_generation_prompt = gr.Textbox(
+            label='ControlNet Prompt',
+            info="Enter a Prompt to generate images using ControlNet and Style-aligned", 
+            )
+    # Button to trigger image generation
+    btn = gr.Button("Generate", size='sm')
+    # Gallery to display generated images
+    gallery = gr.Gallery(label="Style-Aligned ControlNet - Generated images", 
+                           elem_id="gallery",
+                           columns=5, 
+                           rows=1, 
+                           object_fit="contain", 
+                           height="auto",
+                          )
+      
+    btn.click(fn=style_aligned_controlnet, 
+              inputs=[ref_style_prompt, depth_map, ref_image, img_generation_prompt], 
+              outputs=[gallery, ref_style_image], 
+              api_name="style_aligned_controlnet")
+
+
+    # Example inputs for the Gradio interface
+    gr.Examples(
+      examples=[
+        ['A poster in a papercut art style.', False, 'example_image/A.png', 'Letter A in a papercut art style.'],
+        ['A couple sitting a wooden bench, in colorful clay animation, claymation style.', True, 'example_image/train.jpg', 'A train in colorful clay animation, claymation style.'],
+        ['A couple sitting a wooden bench, in clay animation, claymation style.', True, 'example_image/sun.png', 'Sun in clay animation, claymation style.'],
+        ['A bull in a low-poly, colorful origami style.', True, 'example_image/whale.png', 'A whale in a low-poly, colorful origami style.'],
+        ['A house in a painterly, digital illustration style.', True, 'example_image/camel.jpg', 'A camel in a painterly, digital illustration style.'],
+        ['An image in ancient egyptian art style, hieroglyphics style.', True, 'example_image/whale.png', 'A whale in ancient egyptian art style, hieroglyphics style.'],
+      ],
+      inputs=[ref_style_prompt, depth_map, ref_image, img_generation_prompt], 
+      outputs=[gallery, ref_style_image], 
+      fn=style_aligned_controlnet,
+      )
+
+# Launch the Gradio demo   
+demo.launch()

--- a/demo_stylealigned_multidiffusion.py
+++ b/demo_stylealigned_multidiffusion.py
@@ -1,0 +1,99 @@
+import gradio as gr
+import torch
+from diffusers import StableDiffusionPanoramaPipeline, DDIMScheduler
+import sa_handler
+import pipeline_calls
+
+
+# init models
+model_ckpt = "stabilityai/stable-diffusion-2-base"
+scheduler = DDIMScheduler.from_pretrained(model_ckpt, subfolder="scheduler")
+pipeline = StableDiffusionPanoramaPipeline.from_pretrained(
+     model_ckpt, scheduler=scheduler, torch_dtype=torch.float16
+).to("cuda")
+# Configure the pipeline for CPU offloading and VAE slicing
+pipeline.enable_model_cpu_offload()
+pipeline.enable_vae_slicing()
+sa_args = sa_handler.StyleAlignedArgs(share_group_norm=True,
+                                      share_layer_norm=True,
+                                      share_attention=True,
+                                      adain_queries=True,
+                                      adain_keys=True,
+                                      adain_values=False,
+                                     )
+# Initialize the style-aligned handler
+handler = sa_handler.Handler(pipeline)
+handler.register(sa_args)
+
+
+# Define the function to run MultiDiffusion with StyleAligned
+def style_aligned_multidiff(ref_style_prompt, img_generation_prompt):
+    try:
+        view_batch_size = 25  # adjust according to VRAM size
+        reference_latent = torch.randn(1, 4, 64, 64,)
+        images = pipeline_calls.panorama_call(pipeline,
+                                              [ref_style_prompt, img_generation_prompt],
+                                              reference_latent=reference_latent,
+                                              view_batch_size=view_batch_size)
+    
+        return images, gr.Image(value=images[0], visible=True)
+    except Exception as e:
+        raise gr.Error(f"Error in generating images:{e}")
+
+# Create a Gradio UI
+with gr.Blocks() as demo:
+    gr.HTML('<h1 style="text-align: center;">Style-aligned with MultiDiffusion</h1>')
+    with gr.Row():
+      with gr.Column(variant='panel'):
+        # Textbox for reference style prompt
+        ref_style_prompt = gr.Textbox(
+          label='Reference style prompt',
+          info='Enter a Prompt to generate the reference image',
+          placeholder='A poster in a papercut art style.'
+        )
+        # Image display for the reference style image
+        ref_style_image = gr.Image(visible=False, label='Reference style image')
+
+      with gr.Column(variant='panel'):
+        # Textbox for prompt for MultiDiffusion panoramas
+        img_generation_prompt = gr.Textbox(
+          label='MultiDiffusion Prompt',
+          info='Enter a Prompt to generate panoramic images using Style-aligned combined with MultiDiffusion',
+          placeholder= 'A village in a papercut art style.'
+          )
+
+    # Button to trigger image generation
+    btn = gr.Button('Style-aligned MultiDiffusion - Generate', size='sm')
+    # Gallery to display generated style image and the panorama
+    gallery = gr.Gallery(label='Style-Aligned ControlNet - Generated images',
+                           elem_id='gallery',
+                           columns=5,
+                           rows=1,
+                           object_fit='contain',
+                           height='auto',
+                           allow_preview=True,
+                           preview=True,
+                          )
+    # Button click event
+    btn.click(fn=style_aligned_multidiff,
+              inputs=[ref_style_prompt, img_generation_prompt],
+              outputs=[gallery, ref_style_image],
+              api_name='style_aligned_multidiffusion')
+
+    # Example inputs for the Gradio demo
+    gr.Examples(
+      examples=[
+        ['A poster in a papercut art style.', 'A village in a papercut art style.'],
+        ['A poster in a papercut art style.', 'Futuristic cityscape in a papercut art style.'],
+        ['A poster in a papercut art style.', 'A jungle in a papercut art style.'],
+        ['A poster in a flat design style.', 'Girrafes in a flat design style.'],
+        ['A poster in a flat design style.', 'Houses in a flat design style.'],
+        ['A poster in a flat design style.', 'Mountains in a flat design style.'],
+      ],
+      inputs=[ref_style_prompt, img_generation_prompt],
+      outputs=[gallery, ref_style_image],
+      fn=style_aligned_multidiff,
+      )
+
+# Launch the Gradio demo
+demo.launch()

--- a/demo_stylealigned_sdxl.py
+++ b/demo_stylealigned_sdxl.py
@@ -1,0 +1,78 @@
+import gradio as gr
+from diffusers import StableDiffusionXLPipeline, DDIMScheduler
+import torch
+import sa_handler
+
+# init models
+scheduler = DDIMScheduler(beta_start=0.00085, beta_end=0.012, beta_schedule="scaled_linear", clip_sample=False,
+                              set_alpha_to_one=False)
+pipeline = StableDiffusionXLPipeline.from_pretrained(
+    "stabilityai/stable-diffusion-xl-base-1.0", torch_dtype=torch.float16, variant="fp16", use_safetensors=True,
+    scheduler=scheduler
+).to("cuda")
+# Configure the pipeline for CPU offloading and VAE slicing#pipeline.enable_sequential_cpu_offload()
+pipeline.enable_model_cpu_offload() 
+pipeline.enable_vae_slicing()
+# Initialize the style-aligned handler
+handler = sa_handler.Handler(pipeline)
+sa_args = sa_handler.StyleAlignedArgs(share_group_norm=False,
+                                      share_layer_norm=False,
+                                      share_attention=True,
+                                      adain_queries=True,
+                                      adain_keys=True,
+                                      adain_values=False,
+                                     )
+
+handler.register(sa_args, )
+
+# Define the function to generate style-aligned images
+def style_aligned_sdxl(initial_prompt1, initial_prompt2, initial_prompt3, initial_prompt4, initial_prompt5, style_prompt): 
+    try:
+        # Combine the style prompt with each initial prompt
+        sets_of_prompts = [ prompt + ". " + style_prompt for prompt in [initial_prompt1, initial_prompt2, initial_prompt3, initial_prompt4, initial_prompt5,]]
+        # Generate images using the pipeline
+        images = pipeline(sets_of_prompts,).images
+        return images
+    except Exception as e:
+        raise gr.Error(f"Error in generating images: {e}")
+
+with gr.Blocks() as demo:
+    gr.HTML('<h1 style="text-align: center;">Style-aligned SDXL</h1>')
+    with gr.Group():
+      with gr.Column():
+        with gr.Accordion(label='Enter upto 5 different initial prompts', open=True):
+          with gr.Row(variant='panel'):
+            # Textboxes for initial prompts
+            initial_prompt1 = gr.Textbox(label='Initial prompt 1', value='', show_label=False, container=False, placeholder='a toy train')
+            initial_prompt2 = gr.Textbox(label='Initial prompt 2', value='', show_label=False, container=False, placeholder='a toy airplane')
+            initial_prompt3 = gr.Textbox(label='Initial prompt 3', value='', show_label=False, container=False, placeholder='a toy bicycle')
+            initial_prompt4 = gr.Textbox(label='Initial prompt 4', value='', show_label=False, container=False, placeholder='a toy car')
+            initial_prompt5 = gr.Textbox(label='Initial prompt 5', value='', show_label=False, container=False, placeholder='a toy boat')
+        with gr.Row():
+          # Textbox for the style prompt
+          style_prompt = gr.Textbox(label="Enter a style prompt", placeholder='macro photo, 3d game asset')
+        # Button to generate images
+        btn = gr.Button("Generate a set of Style-aligned SDXL images",)
+    # Display the generated images
+    output = gr.Gallery(label="Style-Aligned SDXL Images", elem_id="gallery",columns=5, rows=1, object_fit="contain", height="auto",)
+
+    # Button click event
+    btn.click(fn=style_aligned_sdxl, 
+              inputs=[initial_prompt1, initial_prompt2, initial_prompt3, initial_prompt4, initial_prompt5, style_prompt], 
+              outputs=output, 
+              api_name="style_aligned_sdxl")
+
+    # Providing Example inputs for the demo
+    gr.Examples(examples=[
+                    ["a toy train", "a toy airplane", "a toy bicycle", "a toy car", "a toy boat", "macro photo. 3d game asset."],
+                    ["a toy train", "a toy airplane", "a toy bicycle", "a toy car", "a toy boat", "BW logo. high contrast."],
+                    ["a cat", "a dog", "a bear", "a man on a bicycle", "a girl working on laptop", "minimal origami."],
+                    ["a firewoman", "a Gardner", "a scientist", "a policewoman", "a saxophone player", "made of claymation, stop motion animation."],
+                    ["a firewoman", "a Gardner", "a scientist", "a policewoman", "a saxophone player", "sketch, character sheet."],
+                    ],
+            inputs=[initial_prompt1, initial_prompt2, initial_prompt3, initial_prompt4, initial_prompt5, style_prompt],
+            outputs=[output],
+            fn=style_aligned_sdxl)
+
+# Launch the Gradio demo
+demo.launch()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
-diffusers==0.16.1
+diffusers
 transformers
+accelerate
 mediapy
 ipywidgets
 einops


### PR DESCRIPTION
This PR is adding python files for gradio demos for these three - style-aligned sdxl, style-aligned with contolnet, and style-aligned with multidiffusion. Updated requirements file to use latest diffusers release and added accelerate python library.

The demos would look like this while in action -
- ControlNet

- SDXL

- MultiDiffusion


https://github.com/google/style-aligned/assets/48665385/e7a041e5-5549-41a2-9287-1b6e60ff9b58


https://github.com/google/style-aligned/assets/48665385/4bf6a322-1d52-4a0e-a1f2-526d61592c8b


https://github.com/google/style-aligned/assets/48665385/e605b1f1-fd9a-42b6-abf4-656b2558c0ac

